### PR TITLE
Make EasingBase Objects Callable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ from easing_functions import *
 a = QuadEaseInOut(start=0, end = 3, duration = 10)
 k = a.ease(4) # 4 is a number between 0 and the duration you specified
 #k is the returned value from start to end (0 to 3)
+k2 = a(4) # the ease object can also be called directly, like a function
 
 # example plots:
 import numpy as np
@@ -29,9 +30,9 @@ b = BounceEaseIn(start=0, end=1)
 c = BounceEaseOut(start=0, end=1)
 
 x = np.arange(0, 1, 0.001)
-y0 = list(map(a.ease, x))
-y1 = list(map(b.ease, x))
-y2 = list(map(c.ease, x))
+y0 = list(map(a, x))
+y1 = list(map(b, x))
+y2 = list(map(c, x))
 
 plt.plot(x,y0)
 plt.plot(x,y1)

--- a/easing_functions/easing.py
+++ b/easing_functions/easing.py
@@ -19,6 +19,9 @@ class EasingBase:
         a = self.func(t)
         return self.end * a + self.start * (1 - a)
 
+    def __call__(self, alpha):
+        return self.ease(alpha)
+
 
 """
 Linear


### PR DESCRIPTION
Make ```EasingBase``` and its children callable by adding the ```__call__``` method. This simplifies the API, making it more intuitive and more in-line with how other libraries work. The old ```ease()``` method is still in place for backwards compatibility.

An example:
```python
a = QuadEaseInOut()
k = a(4)
```